### PR TITLE
Add AGENTS instructions for setting up container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS Instructions for Codex
+
+This repository contains a small Java project using LWJGL 2.9.0. There is no build automation or test suite. The following instructions describe how to set up the container and compile the project.
+
+## Setup
+1. Ensure OpenJDK is available. If it is not already installed run:
+   ```bash
+   apt-get update
+   apt-get install -y openjdk-8-jdk
+   ```
+
+## Build
+Compile the sources with the provided LWJGL jars:
+```bash
+mkdir -p bin
+find src -name "*.java" > sources.txt
+javac --release 8 -cp "libs/*" -d bin @sources.txt
+```
+
+## Run
+Execute the example program:
+```bash
+java -cp "libs/*:bin" logic.LSystem
+```
+
+## Tests
+There are no automated tests. Successful compilation is considered a passing check.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for installing Java, compiling, and running the project

## Testing
- `javac --release 8 -encoding ISO-8859-1 -cp "libs/*" -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c779c03408323a8e81fbeff710899